### PR TITLE
Improve country detection and tests

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -127,8 +127,14 @@ class QueryProcessor:
     @staticmethod
     def detect_country(query: str) -> Optional[str]:
         """Detecta el país mencionado en la consulta"""
-        query_lower = query.lower()
-        
+        def normalize(text: str) -> str:
+            import unicodedata
+            text = text.lower()
+            text = unicodedata.normalize('NFKD', text)
+            return ''.join(c for c in text if not unicodedata.combining(c))
+
+        query_norm = normalize(query)
+
         country_mapping = {
             "argentina": "Argentina",
             "méxico": "México",
@@ -146,11 +152,16 @@ class QueryProcessor:
             "bolivia": "Bolivia",
             "estados unidos": "Estados Unidos",
             "usa": "Estados Unidos",
-            "eeuu": "Estados Unidos"
+            "eeuu": "Estados Unidos",
+            "ee.uu.": "Estados Unidos",
+            "ee.uu": "Estados Unidos",
+            "ee uu": "Estados Unidos",
+            "u.s.a.": "Estados Unidos",
+            "eua": "Estados Unidos"
         }
-        
+
         for key, value in country_mapping.items():
-            if key in query_lower:
+            if normalize(key) in query_norm:
                 return value
         
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+class Dummy(types.ModuleType):
+    def __getattr__(self, name):
+        return type(name, (), {"__init__": lambda self, *a, **k: None})
+
+    def __call__(self, *args, **kwargs):
+        return None
+
+# List of modules to fake
+modules = [
+    'supabase',
+    'langchain_openai',
+    'langchain_community',
+    'langchain_community.vectorstores',
+    'langchain.chains',
+    'langchain.memory',
+    'langchain.prompts',
+    'langchain.schema',
+    'langchain.callbacks',
+    'langchain.text_splitter',
+    'dotenv',
+    'pydantic'
+]
+
+for mod in modules:
+    parts = mod.split('.')
+    for i in range(1, len(parts)+1):
+        sub = '.'.join(parts[:i])
+        if sub not in sys.modules:
+            sys.modules[sub] = Dummy(sub)
+
+# provide a no-op load_dotenv
+sys.modules['dotenv'].load_dotenv = lambda *a, **k: None
+
+# specific helpers
+sys.modules['supabase'].create_client = lambda *a, **k: object()

--- a/tests/test_detect_country.py
+++ b/tests/test_detect_country.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from chatbot import QueryProcessor
+
+import pytest
+
+@pytest.mark.parametrize("query,expected", [
+    ("Alertas de México", "México"),
+    ("alertas de mexico", "México"),
+    ("Alerta en Perú", "Perú"),
+    ("Novedades peru", "Perú"),
+    ("Normativa EE.UU.", "Estados Unidos"),
+    ("leyes eeuu", "Estados Unidos"),
+    ("analisis usa", "Estados Unidos"),
+    ("reglas eua", "Estados Unidos"),
+    ("sin pais", None),
+])
+def test_detect_country(query, expected):
+    assert QueryProcessor.detect_country(query) == expected


### PR DESCRIPTION
## Summary
- normalize accent marks when detecting countries
- expand abbreviations mapping for U.S. references
- add pytest setup with dummy modules
- create unit tests for detect_country variations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a17a7ae08325ac6384b2d157b3bb