### PR TITLE
Show source URL in chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Chat Oversia
+
+This repository contains a regulatory alerts chatbot and utilities.
+
+## Features
+- `ImprovedChatbot` for querying Supabase data
+- Script to ingest embeddings
+
+## Source information output
+Each response lists the source documents consulted. Now every document
+includes its `source_url` and the console shows the URL along with the
+title and date for easier reference.

--- a/chatbot.py
+++ b/chatbot.py
@@ -409,12 +409,15 @@ class ImprovedChatbot:
                         "country": doc.metadata.get("country", ""),
                         "institution": doc.metadata.get("institution", ""),
                         "id": doc.metadata.get("id", ""),
+                        "source_url": doc.metadata.get("source_url", ""),
                         "excerpt": doc.page_content[:200] + "..."
                     }
                     response["sources"].append(source_info)
                     
                     print(f"\n[{i+1}] {source_info['title']}")
                     print(f"    📅 {source_info['date']}")
+                    if source_info['source_url']:
+                        print(f"    🔗 {source_info['source_url']}")
                     print(f"    🌍 {source_info['country']}")
                     if source_info['category']:
                         print(f"    📁 {source_info['category']}")


### PR DESCRIPTION
## Summary
- expose `source_url` in the chatbot response metadata
- display the URL in console output
- document the new output behaviour

## Testing
- `python -m py_compile chatbot.py ingest_embeddings.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a17cc02483259a943f8307cc4495