### PR TITLE
Clean imports

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -1,7 +1,6 @@
 import os
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
-import json
 import re
 from supabase import create_client
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
@@ -11,8 +10,6 @@ from langchain.memory import ConversationBufferMemory
 from langchain.prompts import PromptTemplate
 from langchain.schema import Document, BaseRetriever
 from langchain.callbacks import StreamingStdOutCallbackHandler
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-from pydantic import BaseModel
 from dotenv import load_dotenv
 
 # ─── CONFIGURACIÓN ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- remove unused imports from chatbot

## Testing
- `mypy --ignore-missing-imports chatbot.py ingest_embeddings.py`
- `pip install flake8` *(fails: `Tunnel connection failed: 403 Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a17d9060832592bd093894a3d4be